### PR TITLE
fixed bug bumped version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nhppp
 Title: Simulating Nonhomogeneous Poisson Point Processes 
-Version: 0.1.3.9005
+Version: 0.1.3.9006
 Authors@R: 
     c(person(given = "Thomas", 
              family = "Trikalinos", 

--- a/R/vdraw_intensity_step_regular_cpp.R
+++ b/R/vdraw_intensity_step_regular_cpp.R
@@ -47,7 +47,7 @@ vdraw_intensity_step_regular_cpp <- function(lambda = NULL,
   if (!is.matrix(range_t)) {
     range_t <- matrix(rep(range_t, each = nrow(rate)), ncol = 2)
   } else if (nrow(range_t) == 1) {
-    range_t <- range_t[rep(1, nrow(rate)), ]
+    range_t <- range_t[rep(1, nrow(rate)), , drop = FALSE]
   } else if (nrow(range_t) != nrow(rate)) {
     stop("`range_t` should have as many rows as `lambda_maj_matrix` or `Lambda_maj_matrix`")
   } else {
@@ -70,7 +70,7 @@ vdraw_intensity_step_regular_cpp <- function(lambda = NULL,
     if (!is.matrix(subinterval)) {
       subinterval <- matrix(rep(subinterval, each = nrow(rate)), ncol = 2)
     } else if (nrow(subinterval) == 1) {
-      subinterval <- subinterval[rep(1, nrow(rate)), ]
+      subinterval <- subinterval[rep(1, nrow(rate)), , drop = FALSE]
     } else if (nrow(subinterval) != nrow(rate)) {
       stop("`subinterval` should have as many rows as `lambda_matrix` or `Lambda_matrix`")
     }

--- a/R/vdraw_sc_step_regular_cpp.R
+++ b/R/vdraw_sc_step_regular_cpp.R
@@ -55,7 +55,7 @@ vdraw_sc_step_regular_cpp <- function(
     if (!is.matrix(subinterval)) {
       subinterval <- matrix(rep(subinterval, each = nrow(rate)), ncol = 2)
     } else if (nrow(subinterval) == 1) {
-      subinterval <- subinterval[rep(1, nrow(rate)), ]
+      subinterval <- subinterval[rep(1, nrow(rate)), , drop = FALSE]
     } else if (nrow(subinterval) != nrow(rate)) {
       stop("`subinterval` should have as many rows as `lambda_matrix` or `Lambda_matrix`")
     }

--- a/R/vztdraw_sc_step_regular_cpp.R
+++ b/R/vztdraw_sc_step_regular_cpp.R
@@ -34,7 +34,7 @@ vztdraw_sc_step_regular_cpp <- function(Lambda_matrix = NULL,
   if (!is.matrix(range_t)) {
     range_t <- matrix(rep(range_t, each = nrow(rate)), ncol = 2)
   } else if (nrow(range_t) == 1) {
-    range_t <- range_t[rep(1, nrow(rate)), ]
+    range_t <- range_t[rep(1, nrow(rate)), , drop = FALSE]
   } else if (nrow(range_t) != nrow(rate)) {
     stop("`range_t` should have as many rows as `lambda_matrix` or `Lambda_matrix`")
   }

--- a/tests/testthat/test-draw.R
+++ b/tests/testthat/test-draw.R
@@ -1,4 +1,5 @@
 test_that("draw() works with lambda option", {
+  set.seed(123)
   l <- function(t) {
     return(2)
   }
@@ -14,6 +15,7 @@ test_that("draw() works with lambda option", {
 
 
 test_that("draw() works with Lambda option", {
+  set.seed(123)
   L <- function(t) {
     return(2 * t)
   }

--- a/tests/testthat/test-draw_cumulative_intensity_orderstats.R
+++ b/tests/testthat/test-draw_cumulative_intensity_orderstats.R
@@ -1,4 +1,5 @@
 test_that("draw_cumulative_intensity_orderstats() works", {
+  set.seed(123)
   L <- function(t) {
     return(2 * t)
   }

--- a/tests/testthat/test-draw_intensity.R
+++ b/tests/testthat/test-draw_intensity.R
@@ -1,4 +1,5 @@
 test_that("draw_intensity() works", {
+  set.seed(123)
   l <- function(t) {
     return(2)
   }
@@ -36,6 +37,7 @@ test_that("draw_intensity() works", {
 
 
 test_that("draw_intensity() works with linear majorization function", {
+  set.seed(123)
   l <- function(t) {
     return(2)
   }

--- a/tests/testthat/test-draw_intensity_step.R
+++ b/tests/testthat/test-draw_intensity_step.R
@@ -1,4 +1,5 @@
 test_that("draw_intensity_step() works", {
+  set.seed(123)
   l <- function(t) {
     return(rep(2, length(t)))
   }

--- a/tests/testthat/test-draw_sc_step.R
+++ b/tests/testthat/test-draw_sc_step.R
@@ -1,4 +1,5 @@
 test_that("draw_sc_step() arguments work", {
+  set.seed(123)
   expect_no_error(df0 <- draw_sc_step(times_vector = c(0, 10), lambda_vector = 1, atmost1 = TRUE))
   check_ppp_sample_validity(times = df0, t_min = 0, t_max = 10, atmost1 = TRUE)
 

--- a/tests/testthat/test-draw_sc_step_regular.R
+++ b/tests/testthat/test-draw_sc_step_regular.R
@@ -1,4 +1,5 @@
 test_that("draw_sc_step_regular() arguments work", {
+  set.seed(123)
   l <- stats::runif(10)
   L <- cumsum(l)
 

--- a/tests/testthat/test-ppp_agreement.R
+++ b/tests/testthat/test-ppp_agreement.R
@@ -1,4 +1,5 @@
 test_that("PPP methods agree on the first time to event", {
+  set.seed(123)
   r_ppp_next_n <- unlist(lapply(integer(10000), function(x) ppp_next_n(n = 1, rate = 10, t_min = 1)))
   r_ppp_sequential <- unlist(lapply(integer(10000), function(x) ppp_sequential(range_t = c(1, 3), rate = 10, atmost1 = TRUE)))
   compare_ppp_vectors(ppp1 = r_ppp_next_n, ppp2 = r_ppp_sequential, threshold = 0.1, showQQ = TRUE)
@@ -12,6 +13,7 @@ test_that("PPP methods agree on the first time to event", {
 
 
 test_that("draw_sc_step() agrees with strung together constant rates", {
+  set.seed(123)
   r_ppp_sequential <- unlist(lapply(
     integer(10000),
     function(x) {
@@ -43,6 +45,7 @@ test_that("draw_sc_step() agrees with strung together constant rates", {
 
 
 test_that("draw_sc_step_regular() agrees with strung together constant rates", {
+  set.seed(123)
   r_ppp_sequential <- unlist(lapply(
     integer(10000),
     function(x) {
@@ -75,6 +78,7 @@ test_that("draw_sc_step_regular() agrees with strung together constant rates", {
 })
 
 test_that("vdraw_sc_step_regular() agrees with strung together constant rates", {
+  set.seed(123)
   r_ppp_sequential <- unlist(lapply(
     integer(10000),
     function(x) {
@@ -110,6 +114,7 @@ test_that("vdraw_sc_step_regular() agrees with strung together constant rates", 
 
 
 test_that("vdraw_sc_step_regular_cpp() agrees with strung together constant rates", {
+  set.seed(123)
   r_ppp_sequential <- unlist(lapply(
     integer(10000),
     function(x) {
@@ -144,6 +149,7 @@ test_that("vdraw_sc_step_regular_cpp() agrees with strung together constant rate
 
 
 test_that("NHPPP methods agree on the first time to event with constant rate", {
+  set.seed(123)
   l <- function(t) 2
   L <- function(t) 2 * t
   Li <- function(z) z / 2
@@ -169,6 +175,7 @@ test_that("NHPPP methods agree on the first time to event with constant rate", {
 })
 
 test_that("NHPPP linear intensity agrees with general methods", {
+  set.seed(123)
   l <- function(t, alpha = 1, beta = 2) alpha + beta * t
   L <- function(t, alpha = 1, beta = 2, t0 = 1) Lambda_linear_form(t, alpha = alpha, beta = beta, t0 = t0)
   Li <- function(z, alpha = 1, beta = 2, t0 = 1) Lambda_inv_linear_form(z, alpha = alpha, beta = beta, t0 = t0)
@@ -188,6 +195,7 @@ test_that("NHPPP linear intensity agrees with general methods", {
 })
 
 test_that("NHPPP loglinear agrees with general methods", {
+  set.seed(123)
   l <- function(t, alpha = .1, beta = .02) exp(alpha + beta * t)
   L <- function(t, alpha = .1, beta = .02, t0 = 1) Lambda_exp_form(t, alpha = alpha, beta = beta, t0 = t0)
   Li <- function(z, alpha = .1, beta = .02, t0 = 1) Lambda_inv_exp_form(z, alpha = alpha, beta = beta, t0 = t0)

--- a/tests/testthat/test-vdraw_intensity_step_regular_R.R
+++ b/tests/testthat/test-vdraw_intensity_step_regular_R.R
@@ -2,6 +2,7 @@
 ## add tests that have lamda_args
 
 test_that("vdraw_intensity_step_regular_R() works", {
+  set.seed(123)
   lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
   l_args <- list(exponent = 1L)
   lmaj <- matrix(rep(1, 50), ncol = 5)
@@ -51,6 +52,7 @@ test_that("vdraw_intensity_step_regular_R() works", {
 
 
 test_that("vdraw_intensity_step_regular_R() does not break with matrices whose mode is list", {
+  set.seed(123)
   lfun <- function(x, ...) .2 * x
   lmaj <- matrix(rep(1, 50), ncol = 5)
   Lmaj <- mat_cumsum_columns(lmaj)
@@ -73,4 +75,34 @@ test_that("vdraw_intensity_step_regular_R() does not break with matrices whose m
     atmost1 = FALSE
   ))
   check_ppp_sample_validity(Z, t_min = 1, t_max = 5, atmost1 = FALSE)
+})
+
+
+test_that("vdraw_intensity_step_regular_R() works with different majorizers", {
+  set.seed(123)
+  lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
+  l_args <- list(exponent = 1L)
+  lmaj <- matrix(rep(1, 1000), ncol = 5)
+
+  expect_no_error(Z1 <- vdraw_intensity_step_regular_R(
+    lambda = lfun,
+    lambda_args = l_args,
+    lambda_maj_matrix = lmaj,
+    range_t = c(1, 5),
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+  check_ppp_sample_validity(Z1, t_min = 1, t_max = 5)
+
+  expect_no_error(Z2 <- vdraw_intensity_step_regular_R(
+    lambda = lfun,
+    lambda_args = l_args,
+    lambda_maj_matrix = lmaj + 10,
+    range_t = c(1, 5),
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+  check_ppp_sample_validity(Z2, t_min = 1, t_max = 5)
+
+  compare_ppp_vectors(ppp1 = Z1, ppp2 = Z2, threshold = 0.1, showQQ = TRUE)
 })

--- a/tests/testthat/test-vdraw_intensity_step_regular_cpp.R
+++ b/tests/testthat/test-vdraw_intensity_step_regular_cpp.R
@@ -2,6 +2,7 @@
 ## add tests that have lamda_args
 
 test_that("vdraw_intensity_step_regular_cpp() works", {
+  set.seed(123)
   lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
   l_args <- list(exponent = 1L)
   lmaj <- matrix(rep(1, 50), ncol = 5)
@@ -46,11 +47,37 @@ test_that("vdraw_intensity_step_regular_cpp() works", {
     atmost1 = TRUE
   ))
   check_ppp_sample_validity(Z, t_min = 1, t_max = 5, atmost1 = TRUE)
+
+
+  #### Also works for 1 row and range_t being matrix or vector
+
+  # range_t vector
+  expect_no_error(Z <- vdraw_intensity_step_regular_cpp(
+    lambda = lfun,
+    lambda_args = l_args,
+    Lambda_maj_matrix = Lmaj[1, , drop = FALSE],
+    range_t = c(1, 5),
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+  check_ppp_sample_validity(Z, t_min = 1, t_max = 5)
+
+  # range_t matrix
+  expect_no_error(Z <- vdraw_intensity_step_regular_cpp(
+    lambda = lfun,
+    lambda_args = l_args,
+    Lambda_maj_matrix = Lmaj[1, , drop = FALSE],
+    range_t = cbind(1, 5),
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+  check_ppp_sample_validity(Z, t_min = 1, t_max = 5)
 })
 
 
 
 test_that("vdraw_intensity_step_regular_cpp() does not break with matrices whose mode is list", {
+  set.seed(123)
   lfun <- function(x, ...) .2 * x
   lmaj <- matrix(rep(1, 50), ncol = 5)
   Lmaj <- mat_cumsum_columns(lmaj)
@@ -76,10 +103,10 @@ test_that("vdraw_intensity_step_regular_cpp() does not break with matrices whose
 
 
 test_that("vdraw_intensity_step_regular_cpp() works with subinterval", {
+  set.seed(123)
   lfun <- function(x, ...) .2 * x
   lmaj <- matrix(rep(1, 50), ncol = 5)
   Lmaj <- mat_cumsum_columns(lmaj)
-
 
   expect_no_error(Z <- vdraw_intensity_step_regular_cpp(
     lambda = lfun,
@@ -101,10 +128,36 @@ test_that("vdraw_intensity_step_regular_cpp() works with subinterval", {
     atmost1 = FALSE
   ))
   check_ppp_sample_validity(Z, t_min = 2.3, t_max = 4.8, atmost1 = FALSE)
+
+
+  #### Also works for 1 row and range_t, subinterval being matrix or vector
+
+  # range_t, subinterval vectors
+  expect_no_error(Z <- vdraw_intensity_step_regular_cpp(
+    lambda = lfun,
+    lambda_maj_matrix = lmaj[1, , drop = FALSE],
+    range_t = c(1, 5),
+    subinterval = c(2.3, 4.8),
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+  check_ppp_sample_validity(Z, t_min = 2.3, t_max = 4.8, atmost1 = FALSE)
+
+  # range_t,subinterval matrices
+  expect_no_error(Z <- vdraw_intensity_step_regular_cpp(
+    lambda = lfun,
+    lambda_maj_matrix = lmaj[1, , drop = FALSE],
+    range_t = cbind(1, 5),
+    subinterval = cbind(2.3, 4.8),
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+  check_ppp_sample_validity(Z, t_min = 2.3, t_max = 4.8, atmost1 = FALSE)
 })
 
 
 test_that("vdraw_intensity_step_regular_cpp() works with different majorizers", {
+  set.seed(123)
   lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
   l_args <- list(exponent = 1L)
   lmaj <- matrix(rep(1, 1000), ncol = 5)
@@ -137,6 +190,7 @@ test_that("vdraw_intensity_step_regular_cpp() works with different majorizers", 
 
 
 test_that("vdraw_intensity_step_regular_cpp() uses blocked random numbers", {
+  set.seed(123)
   lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
   l_args <- list(exponent = 1L)
   l_ <- function(x) lfun(x, lambda_args = l_args)
@@ -163,78 +217,4 @@ test_that("vdraw_intensity_step_regular_cpp() uses blocked random numbers", {
 
   check_ppp_sample_validity(Z0[[1]], t_min = 1, t_max = 5)
   check_ppp_sample_validity(Z0[[2]], t_min = 1, t_max = 5)
-
-  #
-  #   set.seed(123)
-  #   expect_no_error(Z1 <- vdraw_intensity_step_regular_cpp(
-  #     lambda = lfun,
-  #     lambda_args = l_args,
-  #     lambda_maj_matrix = lmaj1,
-  #     range_t = c(1, 5),
-  #     tol = 10^-6,
-  #     atmost1 = FALSE
-  #   ))
-  #   check_ppp_sample_validity(Z1, t_min = 1, t_max = 5)
-  #
-  #
-  #   set.seed(123)
-  #   expect_no_error(Z10 <- vdraw_intensity_step_regular_cpp(
-  #     lambda = lfun,
-  #     lambda_args = l_args,
-  #     lambda_maj_matrix = lmaj10,
-  #     range_t = c(1, 5),
-  #     tol = 10^-6,
-  #     atmost1 = FALSE
-  #   ))
-  #   check_ppp_sample_validity(Z10, t_min = 1, t_max = 5)
-  #
-  #   compare_ppp_vectors(ppp1 = Z0, ppp2 = Z1, threshold = 0.1, showQQ = TRUE)
-  #   compare_ppp_vectors(ppp1 = Z0, ppp2 = Z10, threshold = 0.1, showQQ = TRUE)
 })
-
-
-
-
-# test_that("vdraw_sc_step_regular_cpp() uses blocked random numbers", {
-#   lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
-#   l_args <- list(exponent = 1L)
-#   l_ <- function(x) lfun(x, lambda_args = l_args)
-#   N <- 1000
-#   lmaj0 <- get_step_majorizer(fun = l_, breaks= matrix(rep(1:11, each = N), nrow = N), is_monotone = FALSE, K =0)
-#   lmaj1 <- get_step_majorizer(fun = l_, breaks= matrix(rep(1:11, each = N), nrow = N), is_monotone = FALSE, K =1)
-#   lmaj10 <- get_step_majorizer(fun = l_, breaks= matrix(rep(1:11, each = N), nrow = N), is_monotone = FALSE, K =10)
-#
-#   expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
-#     lambda = lfun,
-#     lambda_args = l_args,
-#     lambda_maj_matrix = lmaj0,
-#     range_t = c(1, 5),
-#     tol = 10^-6,
-#     atmost1 = FALSE
-#   ))
-#   check_ppp_sample_validity(Z0, t_min = 1, t_max = 5)
-#
-#   expect_no_error(Z1 <- vdraw_sc_step_regular_cpp(
-#     lambda = lfun,
-#     lambda_args = l_args,
-#     lambda_maj_matrix = lmaj1,
-#     range_t = c(1, 5),
-#     tol = 10^-6,
-#     atmost1 = FALSE
-#   ))
-#   check_ppp_sample_validity(Z1, t_min = 1, t_max = 5)
-#
-#
-#   expect_no_error(Z10 <- vdraw_sc_step_regular_cpp(
-#     lambda = lfun,
-#     lambda_args = l_args,
-#     lambda_maj_matrix = lmaj10,
-#     range_t = c(1, 5),
-#     tol = 10^-6,
-#     atmost1 = FALSE
-#   ))
-#   check_ppp_sample_validity(Z10, t_min = 1, t_max = 5)
-#
-#   compare_ppp_vectors(ppp1 = Z0, ppp2 = Z1, threshold = 0.1, showQQ = TRUE)
-#   compare_ppp_vectors(ppp1 = Z0, ppp2 = Z10, threshold = 0.1, showQQ = TRUE)
-# })

--- a/tests/testthat/test-vdraw_sc_step_regular.R
+++ b/tests/testthat/test-vdraw_sc_step_regular.R
@@ -1,4 +1,5 @@
 test_that("vdraw_sc_step_regular() works", {
+  set.seed(123)
   # 1 row matrix
   expect_no_error(Z0 <- vdraw_sc_step_regular(
     Lambda_matrix = matrix(1:5, nrow = 1),
@@ -37,6 +38,7 @@ test_that("vdraw_sc_step_regular() works", {
 })
 
 test_that("vdraw_sc_step_regular() does not break with matrices whose mode is list", {
+  set.seed(123)
   l <- matrix(rep(1, 50), ncol = 5)
   L <- mat_cumsum_columns(l)
 
@@ -52,6 +54,7 @@ test_that("vdraw_sc_step_regular() does not break with matrices whose mode is li
 
 
 test_that("vdraw_sc_step_regular() uses blocked random numbers", {
+  set.seed(123)
   l <- matrix(rep(1, 500), ncol = 5)
   L <- mat_cumsum_columns(l)
 

--- a/tests/testthat/test-vdraw_sc_step_regular_cpp.R
+++ b/tests/testthat/test-vdraw_sc_step_regular_cpp.R
@@ -1,4 +1,5 @@
 test_that("vdraw_sc_step_regular_cpp() works", {
+  set.seed(123)
   # 1 row matrix
   expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),
@@ -41,6 +42,7 @@ test_that("vdraw_sc_step_regular_cpp() works", {
 })
 
 test_that("vdraw_sc_step_regular_cpp() does not break with matrices whose mode is list", {
+  set.seed(123)
   l <- matrix(rep(1, 50), ncol = 5)
   L <- mat_cumsum_columns(l)
 
@@ -56,6 +58,7 @@ test_that("vdraw_sc_step_regular_cpp() does not break with matrices whose mode i
 
 
 test_that("vdraw_sc_step_regular_cpp() uses blocked random numbers", {
+  set.seed(123)
   l <- matrix(rep(1, 500), ncol = 5)
   L <- mat_cumsum_columns(l)
 
@@ -76,6 +79,7 @@ test_that("vdraw_sc_step_regular_cpp() uses blocked random numbers", {
 
 
 test_that("vdraw_sc_step_regular_cpp() works with subinterval", {
+  set.seed(123)
   expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),
     range_t = c(100, 110),
@@ -85,7 +89,7 @@ test_that("vdraw_sc_step_regular_cpp() works with subinterval", {
   ))
   expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),
-    range_t = c(100, 110),
+    range_t = cbind(100, 110),
     subinterval = cbind(100, 110), # 1-row matrix (was a bug)
     tol = 10^-6,
     atmost1 = FALSE

--- a/tests/testthat/test-vdraw_sc_step_regular_cpp.R
+++ b/tests/testthat/test-vdraw_sc_step_regular_cpp.R
@@ -79,10 +79,18 @@ test_that("vdraw_sc_step_regular_cpp() works with subinterval", {
   expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),
     range_t = c(100, 110),
-    subinterval = c(100, 110),
+    subinterval = c(100, 110), # vector
     tol = 10^-6,
     atmost1 = FALSE
   ))
+  expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
+    Lambda_matrix = matrix(1:5, nrow = 1),
+    range_t = c(100, 110),
+    subinterval = cbind(100, 110), # 1-row matrix (was a bug)
+    tol = 10^-6,
+    atmost1 = FALSE
+  ))
+
   check_ppp_sample_validity(Z0, t_min = 100, t_max = 110, atmost1 = FALSE)
   expect_no_error(Z0 <- vdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),

--- a/tests/testthat/test-vztdraw_intensity_step_regular_R.R
+++ b/tests/testthat/test-vztdraw_intensity_step_regular_R.R
@@ -53,7 +53,7 @@ test_that("vztdraw_intensity_step_regular_R() works", {
 
 test_that("vztdraw_intensity_step_regular_R() does not break with matrices whose mode is list", {
   set.seed(123)
-  lfun <- function(x, ...) .2 * x   
+  lfun <- function(x, ...) .2 * x
   lmaj <- matrix(rep(1, 50), ncol = 5)
   Lmaj <- mat_cumsum_columns(lmaj)
 
@@ -75,5 +75,3 @@ test_that("vztdraw_intensity_step_regular_R() does not break with matrices whose
     atmost1 = FALSE
   ))
 })
-
-

--- a/tests/testthat/test-vztdraw_intensity_step_regular_R.R
+++ b/tests/testthat/test-vztdraw_intensity_step_regular_R.R
@@ -2,6 +2,7 @@
 ## add tests that have lamda_args
 
 test_that("vztdraw_intensity_step_regular_R() works", {
+  set.seed(123)
   lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
   l_args <- list(exponent = 1L)
   lmaj <- matrix(rep(1, 50), ncol = 5)
@@ -51,7 +52,8 @@ test_that("vztdraw_intensity_step_regular_R() works", {
 
 
 test_that("vztdraw_intensity_step_regular_R() does not break with matrices whose mode is list", {
-  lfun <- function(x, ...) .2 * x
+  set.seed(123)
+  lfun <- function(x, ...) .2 * x   
   lmaj <- matrix(rep(1, 50), ncol = 5)
   Lmaj <- mat_cumsum_columns(lmaj)
 
@@ -75,31 +77,3 @@ test_that("vztdraw_intensity_step_regular_R() does not break with matrices whose
 })
 
 
-
-test_that("vdraw_intensity_step_regular_R() works with different majorizers", {
-  lfun <- function(x, lambda_args, ...) .2 * x^lambda_args$exponent
-  l_args <- list(exponent = 1L)
-  lmaj <- matrix(rep(1, 1000), ncol = 5)
-
-  expect_no_error(Z1 <- vdraw_intensity_step_regular_R(
-    lambda = lfun,
-    lambda_args = l_args,
-    lambda_maj_matrix = lmaj,
-    range_t = c(1, 5),
-    tol = 10^-6,
-    atmost1 = FALSE
-  ))
-  check_ppp_sample_validity(Z1, t_min = 1, t_max = 5)
-
-  expect_no_error(Z2 <- vdraw_intensity_step_regular_R(
-    lambda = lfun,
-    lambda_args = l_args,
-    lambda_maj_matrix = lmaj + 10,
-    range_t = c(1, 5),
-    tol = 10^-6,
-    atmost1 = FALSE
-  ))
-  check_ppp_sample_validity(Z2, t_min = 1, t_max = 5)
-
-  compare_ppp_vectors(ppp1 = Z1, ppp2 = Z2, threshold = 0.1, showQQ = TRUE)
-})

--- a/tests/testthat/test-vztdraw_sc_step_regular_R.R
+++ b/tests/testthat/test-vztdraw_sc_step_regular_R.R
@@ -1,4 +1,5 @@
 test_that("vztdraw_sc_step_regular_R() works", {
+  set.seed(123)
   # 1 row matrix
   expect_no_error(Z0 <- vztdraw_sc_step_regular_R(
     Lambda_matrix = matrix(1:5, nrow = 1),
@@ -41,6 +42,7 @@ test_that("vztdraw_sc_step_regular_R() works", {
 })
 
 test_that("vztdraw_sc_step_regular_R() does not break with matrices whose mode is list", {
+  set.seed(123)
   l <- matrix(rep(1, 50), ncol = 5)
   L <- mat_cumsum_columns(l)
 

--- a/tests/testthat/test-vztdraw_sc_step_regular_cpp.R
+++ b/tests/testthat/test-vztdraw_sc_step_regular_cpp.R
@@ -1,4 +1,5 @@
 test_that("vztdraw_sc_step_regular_cpp() works", {
+  set.seed(123)
   # 1 row matrix
   expect_no_error(Z0 <- vztdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),
@@ -47,6 +48,7 @@ test_that("vztdraw_sc_step_regular_cpp() works", {
 })
 
 test_that("vztdraw_sc_step_regular_cpp() does not break with matrices whose mode is list", {
+  set.seed(123)
   l <- matrix(rep(1, 50), ncol = 5)
   L <- mat_cumsum_columns(l)
 
@@ -61,6 +63,7 @@ test_that("vztdraw_sc_step_regular_cpp() does not break with matrices whose mode
 
 
 test_that("vztdraw_sc_step_regular_cpp() uses blocked random numbers", {
+  set.seed(123)
   l <- matrix(rep(1, 500), ncol = 5)
   L <- mat_cumsum_columns(l)
 
@@ -80,9 +83,10 @@ test_that("vztdraw_sc_step_regular_cpp() uses blocked random numbers", {
 
 
 test_that("vztdraw_sc_step_regular_cpp() works with subinterval", {
+  set.seed(123)
   expect_no_error(Z0 <- vztdraw_sc_step_regular_cpp(
     Lambda_matrix = matrix(1:5, nrow = 1),
-    range_t = c(100, 110),
+    range_t = cbind(100, 110),
     subinterval = cbind(100, 110), # matrix
     atmost1 = FALSE
   ))

--- a/tests/testthat/test-ztdraw_cumulative_intensity.R
+++ b/tests/testthat/test-ztdraw_cumulative_intensity.R
@@ -1,4 +1,5 @@
 test_that("ztdraw_cumulative_intensity() works", {
+  set.seed(123)
   L <- function(t) {
     return(2 * t)
   }

--- a/tests/testthat/test-ztdraw_intensity.R
+++ b/tests/testthat/test-ztdraw_intensity.R
@@ -1,4 +1,5 @@
 test_that("ztdraw_intensity() works", {
+  set.seed(123)
   l <- function(t) {
     return(2)
   }

--- a/tests/testthat/test-ztdraw_intensity_step.R
+++ b/tests/testthat/test-ztdraw_intensity_step.R
@@ -1,4 +1,5 @@
 test_that("ztdraw_intensity_step() works", {
+  set.seed(123)
   l <- function(t) {
     return(2)
   }

--- a/tests/testthat/test-ztnhppp_agreement.R
+++ b/tests/testthat/test-ztnhppp_agreement.R
@@ -1,4 +1,5 @@
 test_that("ztppp agrees with ppp_sequential for high intensities", {
+  set.seed(123)
   # High intensity, there are practically no zero event trajectories
   r_ppp_t <- unlist(lapply(integer(10000), function(x) ppp_sequential(range_t = c(1, 3), rate = 10, atmost1 = TRUE)))
   r_ztppp <- unlist(lapply(integer(10000), function(x) ztppp(range_t = c(1, 3), rate = 10, atmost1 = TRUE)))
@@ -6,6 +7,7 @@ test_that("ztppp agrees with ppp_sequential for high intensities", {
 })
 
 test_that("ztppp agrees with ppp_sequential for low intensities", {
+  set.seed(123)
   # Low intensity, there are many zero event trajectories -- condition on having >=1 event
   r_ppp_t_low <- unlist(lapply(integer(10000), function(x) ppp_sequential(range_t = c(1, 3), rate = 0.1, atmost1 = TRUE)))
   r_ztppp_low <- unlist(lapply(integer(length(r_ppp_t_low)), function(x) ztppp(range_t = c(1, 3), rate = 0.1, atmost1 = TRUE)))
@@ -13,6 +15,7 @@ test_that("ztppp agrees with ppp_sequential for low intensities", {
 })
 
 test_that("ztNHPPP methods agree on the first time to event with constant rate", {
+  set.seed(123)
   l <- function(t) rep(2, length(t))
   L <- function(t) 2 * t
   Li <- function(z) z / 2
@@ -35,6 +38,7 @@ test_that("ztNHPPP methods agree on the first time to event with constant rate",
 })
 
 test_that("ztNHPPP linear intensity agrees with general methods", {
+  set.seed(123)
   l <- function(t, alpha = 1, beta = 2) alpha + beta * t
   L <- function(t, alpha = 1, beta = 2, t0 = 1) Lambda_linear_form(t, alpha = alpha, beta = beta, t0 = t0)
   Li <- function(z, alpha = 1, beta = 2, t0 = 1) Lambda_inv_linear_form(z, alpha = alpha, beta = beta, t0 = t0)
@@ -49,12 +53,14 @@ test_that("ztNHPPP linear intensity agrees with general methods", {
 
 
 test_that("ztNHPPP linear intensity agrees with linear intensity for high rates", {
+  set.seed(123)
   r_ztnhppp_intens_linear <- unlist(lapply(integer(10000), function(x) ztdraw_sc_linear(alpha = 1, beta = 2, range_t = c(1, 13), atmost1 = TRUE)))
   r_nhppp_intens_linear <- unlist(lapply(integer(10000), function(x) draw_sc_linear(alpha = 1, beta = 2, range_t = c(1, 13), atmost1 = TRUE)))
   compare_ppp_vectors(ppp1 = r_ztnhppp_intens_linear, ppp2 = r_nhppp_intens_linear, threshold = 0.1, showQQ = TRUE)
 })
 
 test_that("ztNHPPP linear intensity agrees with linear intensity for low rates", {
+  set.seed(123)
   r_nhppp_intens_linear <- unlist(lapply(integer(10000), function(x) draw_sc_linear(alpha = 1, beta = 2, range_t = c(1, 1.1), atmost1 = TRUE)))
   r_ztnhppp_intens_linear <- unlist(lapply(integer(length(r_nhppp_intens_linear)), function(x) ztdraw_sc_linear(alpha = 1, beta = 2, range_t = c(1, 1.1), atmost1 = TRUE)))
   compare_ppp_vectors(ppp1 = r_ztnhppp_intens_linear, ppp2 = r_nhppp_intens_linear, threshold = 0.15, showQQ = TRUE)
@@ -62,6 +68,7 @@ test_that("ztNHPPP linear intensity agrees with linear intensity for low rates",
 
 
 test_that("vztdraw_sc_step_regular() agrees with vdraw_sc_step_regular()", {
+  set.seed(123)
   Lmat <- matrix(rep(c(1, 11, 14, 17), 10000), ncol = 4, byrow = TRUE)
   r_vdraw_sc_step_regular <- vdraw_sc_step_regular(Lambda_matrix = Lmat, range_t = c(1, 5), atmost1 = FALSE)
   r_vdraw_sc_step_regular <- r_vdraw_sc_step_regular[!is.na(r_vdraw_sc_step_regular)]
@@ -78,6 +85,7 @@ test_that("vztdraw_sc_step_regular() agrees with vdraw_sc_step_regular()", {
 
 
 test_that("vztdraw_sc_step_regular_cpp() agrees with vdraw_sc_step_regular()", {
+  set.seed(123)
   Lmat <- matrix(rep(c(1, 11, 14, 17), 10000), ncol = 4, byrow = TRUE)
   r_vdraw_sc_step_regular <- vdraw_sc_step_regular(Lambda_matrix = Lmat, range_t = c(1, 5), atmost1 = FALSE)
   r_vdraw_sc_step_regular <- r_vdraw_sc_step_regular[!is.na(r_vdraw_sc_step_regular)]
@@ -95,6 +103,7 @@ test_that("vztdraw_sc_step_regular_cpp() agrees with vdraw_sc_step_regular()", {
 
 
 test_that("ztNHPPP exponential agrees with general methods", {
+  set.seed(123)
   l <- function(t, alpha = .1, beta = .02) exp(alpha + beta * t)
   L <- function(t, alpha = .1, beta = .02, t0 = 1) Lambda_exp_form(t, alpha = alpha, beta = beta, t0 = t0)
   Li <- function(z, alpha = .1, beta = .02, t0 = 1) Lambda_inv_exp_form(z, alpha = alpha, beta = beta, t0 = t0)
@@ -109,6 +118,7 @@ test_that("ztNHPPP exponential agrees with general methods", {
 
 
 test_that("ztNHPPP exponential agrees with NHPPP exponential for high rates", {
+  set.seed(123)
   r_nhppp_intens_exp <- unlist(lapply(integer(10000), function(x) draw_sc_loglinear(alpha = .1, beta = .02, range_t = c(1, 13), atmost1 = TRUE)))
   r_ztnhppp_intens_exp <- unlist(lapply(integer(10000), function(x) ztdraw_sc_loglinear(alpha = .1, beta = .02, range_t = c(1, 13), atmost1 = TRUE)))
   compare_ppp_vectors(ppp1 = r_nhppp_intens_exp, ppp2 = r_ztnhppp_intens_exp, threshold = 0.1, showQQ = TRUE)
@@ -116,6 +126,7 @@ test_that("ztNHPPP exponential agrees with NHPPP exponential for high rates", {
 
 
 test_that("ztNHPPP exponential agrees with NHPPP exponential for low rates", {
+  set.seed(123)
   r_nhppp_intens_exp <- unlist(lapply(integer(10000), function(x) draw_sc_loglinear(alpha = .1, beta = .02, range_t = c(1, 1.1), atmost1 = TRUE)))
   r_ztnhppp_intens_exp <- unlist(lapply(integer(length(r_nhppp_intens_exp)), function(x) ztdraw_sc_loglinear(alpha = .1, beta = .02, range_t = c(1, 1.1), atmost1 = TRUE)))
   compare_ppp_vectors(ppp1 = r_nhppp_intens_exp, ppp2 = r_ztnhppp_intens_exp, threshold = 0.1, showQQ = TRUE)

--- a/tests/testthat/test-ztppp.R
+++ b/tests/testthat/test-ztppp.R
@@ -10,6 +10,4 @@ test_that("ztppp() arguments work", {
   S1 <- methods::new("rstream.mrg32k3a")
   expect_no_error(df2 <- ppp_sequential(range_t = c(0, 10), rate = 1, rng_stream = S1))
   check_ppp_sample_validity(times = df2, t_min = 0, t_max = 10, atleast1 = TRUE)
-
-
 })

--- a/tests/testthat/test-ztppp.R
+++ b/tests/testthat/test-ztppp.R
@@ -1,4 +1,5 @@
 test_that("ztppp() arguments work", {
+  set.seed(123)
   expect_no_error(df0 <- ztppp(range_t = c(0, 10), rate = 1, atmost1 = TRUE))
   check_ppp_sample_validity(times = df0, t_min = 0, t_max = 10, atleast1 = TRUE, atmost1 = TRUE)
 
@@ -11,8 +12,4 @@ test_that("ztppp() arguments work", {
   check_ppp_sample_validity(times = df2, t_min = 0, t_max = 10, atleast1 = TRUE)
 
 
-  # # check RNGClass
-  # expect_no_error(S2 <- readRDS(file.path("example_RNGCLass.rds"))$unpack())
-  # expect_no_error(df3 <- ppp_sequential(range_t = c(0, 10), rate = 1, rng_stream = S2))
-  # check_ppp_sample_validity(times = df3, t_min = 0, t_max = 10, atleast1 = TRUE)
 })


### PR DESCRIPTION
Fixed a bug where `vdraw_sc_step_regular_cpp()` was breaking when you had 1 row for samples and subinterval was a 1-row matrix. 

Closes #40 